### PR TITLE
fix(icon): set icon font-size

### DIFF
--- a/packages/mikado_reborn/src/components/Icon/Icon.scss
+++ b/packages/mikado_reborn/src/components/Icon/Icon.scss
@@ -9,6 +9,7 @@
   font-variant: normal;
   text-transform: none;
   line-height: 1;
+  font-size: 2rem;
   height: 2rem;
   width: 2rem;
 


### PR DESCRIPTION
Icon font-size was overridden in small buttons, resulting in broken alignment as icon size is now set to 2rem.