### PR TITLE
fix(app): set font size

### DIFF
--- a/packages/mikado_reborn/src/components/App/App.scss
+++ b/packages/mikado_reborn/src/components/App/App.scss
@@ -1,6 +1,8 @@
 @import '../../assets/styles/styles.scss';
 
 .mkr__app {
+  font-size: 2rem;
+
   /* COLORS */
 
   @each $name, $color in $colors {
@@ -34,5 +36,9 @@
       }
     }
   }
+}
+
+html {
+  font-size: 50%;
 }
 


### PR DESCRIPTION
We removed font-size attribute but now it breaks the Storybook.
On the front, the base font size should be overwritten and I moved the default font size into mkr-app so we don't need to specify it.