### PR TITLE
fix(interactive-icon): add default slot and enforce styles

### DIFF
--- a/packages/mikado_reborn/src/components/InteractiveIcon/InteractiveIcon.scss
+++ b/packages/mikado_reborn/src/components/InteractiveIcon/InteractiveIcon.scss
@@ -25,6 +25,8 @@ $themes: (
   padding: 0.5rem;
   border-radius: 4px;
   cursor: pointer;
+  appearance: none;
+  line-height: 0;
 
   @each $themeName, $themeValues in $themes {
     &--#{$themeName} {

--- a/packages/mikado_reborn/src/components/InteractiveIcon/InteractiveIcon.vue
+++ b/packages/mikado_reborn/src/components/InteractiveIcon/InteractiveIcon.vue
@@ -1,6 +1,7 @@
 <template>
   <button :class="classes" @click="click">
     <mkr-icon :name="name" />
+    <slot />
   </button>
 </template>
 


### PR DESCRIPTION
Interactive Icon can now have a label.
We also need to enforce some styles to prevent tailwind override.