### PR TITLE
feat(tooltip): add topLevel prop for overflow hidden areas

### DIFF
--- a/packages/doc/src/stories/Tooltip.stories.js
+++ b/packages/doc/src/stories/Tooltip.stories.js
@@ -21,3 +21,21 @@ Tooltip.args = {
   label: 'Access chat',
   disabled: false,
 };
+
+const TopLevelTemplate = (args) => ({
+  props: Object.keys(args),
+  template: `
+    <div style="width:auto;height:auto;overflow:hidden;">
+      <mkr-tooltip v-bind="$props">
+        <mkr-contained-button size="medium" icon="chat" theme="primary" />
+      </mkr-tooltip>
+    </div>
+  `,
+});
+
+export const TooltipTopLevel = TopLevelTemplate.bind({});
+TooltipTopLevel.args = {
+  label: 'Access chat',
+  disabled: false,
+  topLevel: true,
+};

--- a/packages/mikado_reborn/src/components/Tooltip/Tooltip.vue
+++ b/packages/mikado_reborn/src/components/Tooltip/Tooltip.vue
@@ -25,12 +25,15 @@ import { createPopper, Instance as PopperInstance } from '@popperjs/core';
 import Uuid from '../../mixins/uuid';
 
 @Component
-export default class PopUp extends Mixins(Uuid) {
+export default class Tooltip extends Mixins(Uuid) {
   @Prop({ type: String, default: '' })
   readonly label!: string;
 
   @Prop({ type: Boolean, default: false })
   readonly disabled!: boolean;
+
+  @Prop({ type: Boolean, default: false })
+  readonly topLevel!: boolean;
 
   opened = false;
 
@@ -51,6 +54,10 @@ export default class PopUp extends Mixins(Uuid) {
   mounted(): void {
     const anchor = this.$refs.anchor as HTMLElement;
     const tooltip = this.$refs.tooltip as HTMLElement;
+
+    if (this.topLevel) {
+      this.$app.$el.insertBefore(tooltip, this.$app.$el.children[0]);
+    }
 
     this.popperInstance = createPopper(anchor, tooltip, {
       modifiers: [


### PR DESCRIPTION
### Context

Add a topLevel prop on tooltip to show tooltip even if the container has an overflow hidden rule.
This will be useful for places where we want the tooltip to be over everything in the app.