### PR TITLE
refactor(modal): improve responsive & adding overlay option directly in the modal

### DIFF
--- a/packages/doc/src/stories/Modal.stories.js
+++ b/packages/doc/src/stories/Modal.stories.js
@@ -1,9 +1,5 @@
 import { MkrModal } from '../../../mikado_reborn/src/components';
 import { sizes } from '../../../mikado_reborn/src/components/Modal/Modal.vue';
-import { MkrContainedButton } from '../../../mikado_reborn/src/components';
-import { MkrTextarea } from '../../../mikado_reborn/src/components';
-import { MkrTextfield } from '../../../mikado_reborn/src/components';
-import { MkrDropdown } from '../../../mikado_reborn/src/components';
 
 export default {
   title: 'Components/Modal',
@@ -54,9 +50,8 @@ const ModalWithOverlayTemplate = (args, { argTypes }) => ({
   },
   template: `
     <div>
-      <mkr-overlay :opened="showModal" />
       <mkr-modal v-bind="$props" v-model="showModal">
-      <div style="display: flex; flex-direction: column">
+        <div style="display: flex; flex-direction: column">
           <h1>Form</h1>
 
           <div style="margin: 15px 0;">
@@ -83,7 +78,9 @@ const ModalWithOverlayTemplate = (args, { argTypes }) => ({
 });
 
 export const ModalWithOverlay = ModalWithOverlayTemplate.bind({});
-ModalWithOverlay.args = {};
+ModalWithOverlay.args = {
+  overlay: true
+};
 
 export const UnclosableModal = ModalWithOverlayTemplate.bind({});
 UnclosableModal.args = {

--- a/packages/mikado_reborn/src/components/Modal/Modal.scss
+++ b/packages/mikado_reborn/src/components/Modal/Modal.scss
@@ -2,21 +2,21 @@
 
 .mkr__modal {
   $modal: &;
+
   display: none;
   position: fixed;
   left: 50vw;
   top: 50vh;
   z-index: 1500;
   transform: translateX(-50%) translateY(-50%);
+  max-width: 95vw;
 
   &--medium {
-    width: 50vw;
-    max-width: 800px;
+    width: 800px;
   }
 
   &--large {
-    width: 80vw;
-    max-width: 1100px;
+    width: 1100px;
   }
 
   &--opened {

--- a/packages/mikado_reborn/src/components/Modal/Modal.vue
+++ b/packages/mikado_reborn/src/components/Modal/Modal.vue
@@ -1,29 +1,32 @@
 <template>
-  <mkr-card
-    role="dialog"
-    :aria-modal="opened"
-    class="mkr__modal"
-    :class="[
-      `mkr__modal--${size}`,
-      {
-        'mkr__modal--opened': opened,
-        'mkr__modal--slim': slim,
-      },
-    ]"
-    elevated
-    radius="large"
-  >
-    <mkr-interactive-icon
-      v-if="closeable"
-      class="mkr__modal__close"
-      name="cross"
-      color="neutral"
-      @click="onClickClose"
-    />
-    <div ref="modalContent" class="mkr__modal__content">
-      <slot />
-    </div>
-  </mkr-card>
+  <div>
+    <mkr-overlay v-if="overlay" :opened="opened" />
+    <mkr-card
+      role="dialog"
+      :aria-modal="opened"
+      class="mkr__modal"
+      :class="[
+        `mkr__modal--${size}`,
+        {
+          'mkr__modal--opened': opened,
+          'mkr__modal--slim': slim,
+        },
+      ]"
+      elevated
+      radius="large"
+    >
+      <mkr-interactive-icon
+        v-if="closeable"
+        class="mkr__modal__close"
+        name="cross"
+        color="neutral"
+        @click="onClickClose"
+      />
+      <div ref="modalContent" class="mkr__modal__content">
+        <slot />
+      </div>
+    </mkr-card>
+  </div>
 </template>
 
 <script lang="ts">
@@ -36,6 +39,7 @@ import {
 } from 'vue-property-decorator';
 import { MkrCard } from '../Card';
 import { MkrInteractiveIcon } from '../InteractiveIcon';
+import { MkrOverlay } from '../Overlay';
 import focusTrap from './focusTrap';
 
 export const sizes = {
@@ -47,6 +51,7 @@ export const sizes = {
   components: {
     MkrCard,
     MkrInteractiveIcon,
+    MkrOverlay,
   },
 })
 export default class Modal extends Vue {
@@ -64,6 +69,9 @@ export default class Modal extends Vue {
 
   @Prop({ type: Boolean, default: true })
   readonly closeable!: boolean;
+
+  @Prop({ type: Boolean, default: false })
+  readonly overlay!: boolean;
 
   @Prop({ type: String, default: null })
   readonly focusFirstSelector!: string;


### PR DESCRIPTION
# Responsive improvement

> In small screen

### From : 

![Capture d’écran 2021-11-24 à 10 54 12](https://user-images.githubusercontent.com/12446546/143217090-5ec29bc2-385e-4ab9-9092-ea866476d50a.png)

### To: 

![Capture d’écran 2021-11-24 à 10 54 46](https://user-images.githubusercontent.com/12446546/143217174-ab8a23ed-d017-4ebc-8bfc-cfdef305aa84.png)

# Adding overlay option directly in modal component

To prevent the developer from having to add the <MkrOverlay /> above the modal, I added an `overlay` prop option