### PR TITLE
refactor(mkr-text-field) adding possibilty to bind native attrs

### DIFF
--- a/packages/mikado_reborn/src/components/Textfield/Textfield.vue
+++ b/packages/mikado_reborn/src/components/Textfield/Textfield.vue
@@ -36,6 +36,7 @@ import MkrContainedButton from '../Button/Contained/ContainedButton';
     MkrContainedButton,
     MkrIcon,
   },
+  inheritAttrs: false,
 })
 export default class TextField extends Vue {
     @Prop({ type: String })
@@ -53,7 +54,7 @@ export default class TextField extends Vue {
     @Prop({
       default: 'text',
       type: String,
-      validator: (type) => ['text', 'email', 'password', 'date', 'number'].includes(type),
+      validator: (type) => ['text', 'email', 'password', 'date'].includes(type),
     })
     type!: string
 

--- a/packages/mikado_reborn/src/components/Textfield/Textfield.vue
+++ b/packages/mikado_reborn/src/components/Textfield/Textfield.vue
@@ -7,8 +7,8 @@
         :value="value"
         :type="getType"
         :placeholder="placeholder"
-        @focus="focused = true"
-        @blur="focused = false"
+        @focus="onFocus"
+        @blur="onBlur"
         @input="emitInput"
         @change="emitChange"
       >
@@ -92,6 +92,16 @@ export default class TextField extends Vue {
       if (input) {
         this.$emit('change', input.value);
       }
+    }
+
+    onFocus(event: Event) {
+      this.focused = true;
+      this.$emit('focus', event);
+    }
+
+    onBlur(event: Event) {
+      this.focused = false;
+      this.$emit('blur', event);
     }
 }
 </script>

--- a/packages/mikado_reborn/src/components/Textfield/Textfield.vue
+++ b/packages/mikado_reborn/src/components/Textfield/Textfield.vue
@@ -3,11 +3,12 @@
     <div class="mkr__textfield__inner">
       <mkr-icon v-if="iconName" :color="iconColor" :name="iconName"/>
       <input
+        v-bind="$attrs"
+        :value="value"
         :type="getType"
+        :placeholder="placeholder"
         @focus="focused = true"
         @blur="focused = false"
-        :placeholder="placeholder"
-        :value="value"
         @input="emitInput"
         @change="emitChange"
       >
@@ -52,7 +53,7 @@ export default class TextField extends Vue {
     @Prop({
       default: 'text',
       type: String,
-      validator: (type) => ['text', 'email', 'password', 'date'].includes(type),
+      validator: (type) => ['text', 'email', 'password', 'date', 'number'].includes(type),
     })
     type!: string
 

--- a/packages/mikado_reborn/src/components/Textfield/Textfield.vue
+++ b/packages/mikado_reborn/src/components/Textfield/Textfield.vue
@@ -11,6 +11,9 @@
         @blur="onBlur"
         @input="emitInput"
         @change="emitChange"
+        @keyup="onKeyup"
+        @keydown="onKeydown"
+        @click="onClick"
       >
       <mkr-icon v-if="error" name="exclamation-circle" color="danger" />
     </div>
@@ -102,6 +105,18 @@ export default class TextField extends Vue {
     onBlur(event: Event) {
       this.focused = false;
       this.$emit('blur', event);
+    }
+
+    onKeydown(event: KeyboardEvent) {
+      this.$emit('keydown', event);
+    }
+
+    onKeyup(event: KeyboardEvent) {
+      this.$emit('keydown', event);
+    }
+
+    onClick(event: Event) {
+      this.$emit('click', event);
     }
 }
 </script>


### PR DESCRIPTION
Dans le but d'utiliser l'input pour créer un select, j'ai besoin de binder des attributs natif à l'input du composant

Dans mon cas, j'ai besoin de pouvoir faire ça : 

```html
<MkrTextfield v-model="value" readonly />
```

Et je pense qu'il est bon d'ouvrir le composant aux possibilités natives

