### PR TITLE
feat(modal): added option to make it scrollable & improve accessibility & added header and footer

### DIFF
--- a/packages/doc/src/stories/Modal.stories.js
+++ b/packages/doc/src/stories/Modal.stories.js
@@ -79,10 +79,16 @@ const ModalWithOverlayTemplate = (args, { argTypes }) => ({
 
 export const ModalWithOverlay = ModalWithOverlayTemplate.bind({});
 ModalWithOverlay.args = {
-  overlay: true
+  overlay: true,
 };
 
 export const UnclosableModal = ModalWithOverlayTemplate.bind({});
 UnclosableModal.args = {
   closeable: false,
+};
+
+export const ScrollableModal = ModalWithOverlayTemplate.bind({});
+ScrollableModal.args = {
+  overlay: true,
+  scrollable: true,
 };

--- a/packages/doc/src/stories/Modal.stories.js
+++ b/packages/doc/src/stories/Modal.stories.js
@@ -92,3 +92,51 @@ ScrollableModal.args = {
   overlay: true,
   scrollable: true,
 };
+
+const ModalWithFooterTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  data: () => ({
+    showModal: false,
+    selectModel: null,
+  }),
+  methods: {
+    open() {
+      this.showModal = true;
+    },
+  },
+  template: `
+    <div>
+      <mkr-modal v-bind="$props" v-model="showModal" >
+        <div style="display: flex; flex-direction: column">
+          <h1>Form</h1>
+
+          <div style="margin: 15px 0;">
+            <label>Input label</label>
+            <mkr-textfield type="text" />
+          </div>
+
+          <div>
+            <label>Textarea label</label>
+            <mkr-textarea></mkr-textarea>
+          </div>
+
+          <div style="margin: 15px 0;">
+            <label>Select label</label>
+            <mkr-dropdown v-model="selectModel" :items="['option1', 'option2']" />
+          </div>
+        </div>
+        <template #footer>
+          <div style="text-align: right; width: 100%;">
+            <mkr-contained-button size="small">Submit</mkr-contained-button>
+          </div>
+        </template>
+      </mkr-modal>
+      <mkr-contained-button @click="open">Open Modal</mkr-contained-button>
+    </div>
+  `,
+});
+export const ModalWithFooter = ModalWithFooterTemplate.bind({});
+ModalWithFooter.args = {
+  overlay: true,
+  scrollable: true,
+};

--- a/packages/mikado_reborn/src/components/Modal/Modal.scss
+++ b/packages/mikado_reborn/src/components/Modal/Modal.scss
@@ -12,7 +12,7 @@
   max-width: 95vw;
 
   &__header {
-    padding: 0.5rem;
+    padding: 1rem;
     position: sticky;
     top: 0;
     right: 0;
@@ -25,6 +25,21 @@
     &__close {
       margin-right: 1rem;
     }
+  }
+
+  &__content {
+    padding: 0 5rem 5rem;
+  }
+
+  &__footer {
+    padding: 1rem;
+    position: sticky;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    background-color: map-get($colors, 'white');
+    min-height: 5rem;
+    display: flex;
   }
 
   &--medium {
@@ -40,19 +55,25 @@
   }
 
   &--scrollable {
-    overflow-y: auto;
     max-height: 95vh;
+    display: flex;
+    flex-direction: column;
+
+    & #{$modal}__content {
+      flex: 1;
+      overflow-y: auto;
+    }
   }
 
-  &--scrolled header {
+  &--scrolled #{$modal}__header {
+    box-shadow: 0px 0px 8px 0px map-get($colors, 'neutral-20');
+  }
+
+  &--has-scroll:not(#{$modal}--fully-scrolled) #{$modal}__footer {
     box-shadow: 0px 0px 8px 0px map-get($colors, 'neutral-20');
   }
 
   &--slim #{$modal}__content {
     padding: 0;
-  }
-
-  &__content {
-    padding: 0 5rem 5rem;
   }
 }

--- a/packages/mikado_reborn/src/components/Modal/Modal.scss
+++ b/packages/mikado_reborn/src/components/Modal/Modal.scss
@@ -11,6 +11,22 @@
   transform: translateX(-50%) translateY(-50%);
   max-width: 95vw;
 
+  &__header {
+    padding: 0.5rem;
+    position: sticky;
+    top: 0;
+    right: 0;
+    left: 0;
+    background-color: map-get($colors, 'white');
+    min-height: 5rem;
+    display: flex;
+    align-items: flex-start;
+
+    &__close {
+      margin-right: 1rem;
+    }
+  }
+
   &--medium {
     width: 800px;
   }
@@ -23,17 +39,20 @@
     display: block;
   }
 
+  &--scrollable {
+    overflow-y: auto;
+    max-height: 95vh;
+  }
+
+  &--scrolled header {
+    box-shadow: 0px 0px 8px 0px map-get($colors, 'neutral-20');
+  }
+
   &--slim #{$modal}__content {
     padding: 0;
   }
 
-  &__close {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-  }
-
   &__content {
-    padding: 5rem;
+    padding: 0 5rem 5rem;
   }
 }

--- a/packages/mikado_reborn/src/components/Modal/Modal.vue
+++ b/packages/mikado_reborn/src/components/Modal/Modal.vue
@@ -11,9 +11,9 @@
           'mkr__modal--opened': opened,
           'mkr__modal--slim': slim,
           'mkr__modal--scrollable': scrollable,
-          'mkr__modal--scrolled': isScrolled,
-          'mkr__modal--has-scroll': hasScroll,
-          'mkr__modal--fully-scrolled': isFullyScrolled,
+          'mkr__modal--scrolled': isScrolled && scrollable,
+          'mkr__modal--has-scroll': hasScroll && scrollable,
+          'mkr__modal--fully-scrolled': isFullyScrolled && scrollable,
         },
       ]"
       elevated
@@ -138,7 +138,10 @@ export default class Modal extends Vue {
   mounted(): void {
     const app = this.$app;
     app.$el.insertBefore(this.$el, app.$el.children[0]);
-    this.setScrollState();
+
+    if (this.scrollable) {
+      this.setScrollState();
+    }
   }
 
   destroyed(): void {
@@ -177,8 +180,9 @@ export default class Modal extends Vue {
     }
   }
 
-  async setScrollState(event?: UIEvent) {
-    await this.$nextTick();
+  setScrollState(event?: UIEvent) {
+    if (!this.scrollable) return;
+
     setTimeout(() => {
       const target = event?.target as Element ?? this.$refs.modalContent;
 

--- a/packages/mikado_reborn/src/components/Modal/Modal.vue
+++ b/packages/mikado_reborn/src/components/Modal/Modal.vue
@@ -26,9 +26,7 @@
           size="small"
           @click="onClickClose"
         />
-        <slot name="title">
-          <h2>COOUCOU</h2>
-        </slot>
+        <slot name="title" />
       </header>
       <main ref="modalContent" class="mkr__modal__content">
         <slot />

--- a/packages/mikado_reborn/src/components/Modal/Modal.vue
+++ b/packages/mikado_reborn/src/components/Modal/Modal.vue
@@ -12,11 +12,12 @@
           'mkr__modal--slim': slim,
           'mkr__modal--scrollable': scrollable,
           'mkr__modal--scrolled': isScrolled,
+          'mkr__modal--has-scroll': hasScroll,
+          'mkr__modal--fully-scrolled': isFullyScrolled,
         },
       ]"
       elevated
       radius="large"
-      @scroll="setScrollState"
     >
       <header class="mkr__modal__header">
         <mkr-text-button
@@ -28,10 +29,10 @@
         />
         <slot name="title" />
       </header>
-      <main ref="modalContent" class="mkr__modal__content">
+      <main ref="modalContent" class="mkr__modal__content" @scroll="setScrollState">
         <slot />
       </main>
-      <footer v-if="$slots['footer']">
+      <footer class="mkr__modal__footer" v-if="$slots['footer']">
         <slot name="footer" />
       </footer>
     </mkr-card>
@@ -94,6 +95,10 @@ export default class Modal extends Vue {
 
   isScrolled = false
 
+  isFullyScrolled = false
+
+  hasScroll = false
+
   $refs!: {
     modalContent: HTMLDivElement;
   };
@@ -133,6 +138,7 @@ export default class Modal extends Vue {
   mounted(): void {
     const app = this.$app;
     app.$el.insertBefore(this.$el, app.$el.children[0]);
+    this.setScrollState();
   }
 
   destroyed(): void {
@@ -171,16 +177,21 @@ export default class Modal extends Vue {
     }
   }
 
-  setScrollState(event: UIEvent) {
-    const target = event.target as Element | undefined;
+  async setScrollState(event?: UIEvent) {
+    await this.$nextTick();
+    setTimeout(() => {
+      const target = event?.target as Element ?? this.$refs.modalContent;
 
-    if (!target) return;
+      if (!target) return;
 
-    if (target.scrollTop >= 20) {
-      this.isScrolled = true;
-    } else {
-      this.isScrolled = false;
-    }
+      const isScrolled = target.scrollTop >= 20;
+      const hasScroll = target.clientHeight < target.scrollHeight;
+      const isFullyScrolled = target.scrollHeight - target.scrollTop - target.clientHeight < 20;
+
+      this.isScrolled = isScrolled;
+      this.isFullyScrolled = isFullyScrolled;
+      this.hasScroll = hasScroll;
+    }, 200);
   }
 }
 </script>

--- a/packages/mikado_reborn/src/components/Modal/Modal.vue
+++ b/packages/mikado_reborn/src/components/Modal/Modal.vue
@@ -19,7 +19,7 @@
       elevated
       radius="large"
     >
-      <header class="mkr__modal__header">
+      <div class="mkr__modal__header">
         <mkr-text-button
           class="mkr__modal__header__close"
           type="button"
@@ -28,13 +28,13 @@
           @click="onClickClose"
         />
         <slot name="title" />
-      </header>
-      <main ref="modalContent" class="mkr__modal__content" @scroll="setScrollState">
+      </div>
+      <div ref="modalContent" class="mkr__modal__content" @scroll="setScrollState">
         <slot />
-      </main>
-      <footer class="mkr__modal__footer" v-if="$slots['footer']">
+      </div>
+      <div class="mkr__modal__footer" v-if="$slots['footer']">
         <slot name="footer" />
-      </footer>
+      </div>
     </mkr-card>
   </div>
 </template>

--- a/packages/mikado_reborn/src/components/Modal/Modal.vue
+++ b/packages/mikado_reborn/src/components/Modal/Modal.vue
@@ -10,21 +10,32 @@
         {
           'mkr__modal--opened': opened,
           'mkr__modal--slim': slim,
+          'mkr__modal--scrollable': scrollable,
+          'mkr__modal--scrolled': isScrolled,
         },
       ]"
       elevated
       radius="large"
+      @scroll="setScrollState"
     >
-      <mkr-interactive-icon
-        v-if="closeable"
-        class="mkr__modal__close"
-        name="cross"
-        color="neutral"
-        @click="onClickClose"
-      />
-      <div ref="modalContent" class="mkr__modal__content">
+      <header class="mkr__modal__header">
+        <mkr-text-button
+          class="mkr__modal__header__close"
+          type="button"
+          icon="cross"
+          size="small"
+          @click="onClickClose"
+        />
+        <slot name="title">
+          <h2>COOUCOU</h2>
+        </slot>
+      </header>
+      <main ref="modalContent" class="mkr__modal__content">
         <slot />
-      </div>
+      </main>
+      <footer v-if="$slots['footer']">
+        <slot name="footer" />
+      </footer>
     </mkr-card>
   </div>
 </template>
@@ -40,6 +51,7 @@ import {
 import { MkrCard } from '../Card';
 import { MkrInteractiveIcon } from '../InteractiveIcon';
 import { MkrOverlay } from '../Overlay';
+import { MkrTextButton } from '../Button';
 import focusTrap from './focusTrap';
 
 export const sizes = {
@@ -52,6 +64,7 @@ export const sizes = {
     MkrCard,
     MkrInteractiveIcon,
     MkrOverlay,
+    MkrTextButton,
   },
 })
 export default class Modal extends Vue {
@@ -73,10 +86,15 @@ export default class Modal extends Vue {
   @Prop({ type: Boolean, default: false })
   readonly overlay!: boolean;
 
+  @Prop({ type: Boolean, default: false })
+  readonly scrollable!: boolean;
+
   @Prop({ type: String, default: null })
   readonly focusFirstSelector!: string;
 
   focusTrapListenerCleanup: ReturnType<typeof focusTrap> = null;
+
+  isScrolled = false
 
   $refs!: {
     modalContent: HTMLDivElement;
@@ -152,6 +170,18 @@ export default class Modal extends Vue {
   keydownHandler(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       this.$emit('close', false);
+    }
+  }
+
+  setScrollState(event: UIEvent) {
+    const target = event.target as Element | undefined;
+
+    if (!target) return;
+
+    if (target.scrollTop >= 20) {
+      this.isScrolled = true;
+    } else {
+      this.isScrolled = false;
     }
   }
 }


### PR DESCRIPTION
# Changelog

## Make it scrollable

**Context : For small screen, sometime the modal is too big and it's impossible to click on the CTA in the bottom**

- Added the `scrollable` option to make it scrollable and have access to all the content

## Accessibility

**Context: The current close "button" is too small to be friendly accessible - cf: [Size matters](https://dequeuniversity.com/resources/wcag2.1/2.5.5-target-size#:~:text=The%20W3C%20recommends%20a%20minimum,used%20targets%20be%20made%20larger.)**

- Use a real button `<mkr-text-button />` for the close button instead the `<mkr-icon />`

## Header & Footer

**Context: To always have the close button accessible when the modal is scrolled - Same for a potentiel CTA in the footer**

- Added a `<div "footer" />` and `<div "header" />` in sticky position
- The "close button" is in the "header" now 
- The "footer" is present only if the slot is provided
- **Shadow**: A shadow appear on the header when the content is scrolled - The shadow on the footer disappear when the content is fully scrolled

# DEMO

![main_large](https://user-images.githubusercontent.com/12446546/145021928-c3484aca-92a3-495c-bd84-3ac9d863c152.gif)


