### PR TITLE
refactor(nav-item): support router link

### DIFF
--- a/packages/mikado_reborn/package.json
+++ b/packages/mikado_reborn/package.json
@@ -24,7 +24,8 @@
     "*.scss"
   ],
   "peerDependencies": {
-    "vue": "^2.6.11"
+    "vue": "^2.6.11",
+    "vue-router": "^3.0.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.0",

--- a/packages/mikado_reborn/package.json
+++ b/packages/mikado_reborn/package.json
@@ -27,6 +27,11 @@
     "vue": "^2.6.11",
     "vue-router": "^3.0.0"
   },
+  "peerDependenciesMeta": {
+    "vue-router": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@popperjs/core": "^2.11.0",
     "core-js": "^3.19.3",

--- a/packages/mikado_reborn/src/components/NavItem/NavItem.ts
+++ b/packages/mikado_reborn/src/components/NavItem/NavItem.ts
@@ -36,6 +36,18 @@ export default class NavItem extends Vue {
     return Boolean(this.$slots.default?.length);
   }
 
+  get isRouterLink(): boolean {
+    return !!this.$attrs.to;
+  }
+
+  get component(): string {
+    if (this.isRouterLink) {
+      return 'RouterLink';
+    }
+
+    return 'a';
+  }
+
   /**
    * Passthrough click event
    */
@@ -53,7 +65,7 @@ export default class NavItem extends Vue {
     }
 
     const link = createElement(
-      'a',
+      this.component,
       {
         attrs: this.$attrs,
         on: {


### PR DESCRIPTION
# Changelog

## Support `<RouterLink />` to simplify the syntax

### Instead of

```html
<NuxtLink
  v-slot="{ href, navigate }"
  :to="{
    name: 'chat-notifications',
  }"
>
  <MkrNavItem
    :href="href"
    @click="navigate"
  >
    Content
  </MkrNavItem>
</NuxtLink>
```

### You can write this 

```html
<MkrNavItem
  :to="{
    name: 'chat-notifications',
  }"
>
  Content
</MkrNavItem>
```