### PR TITLE
feat(progressbar): add shrinkEmoji property

### DIFF
--- a/packages/doc/src/stories/Progressbar.stories.js
+++ b/packages/doc/src/stories/Progressbar.stories.js
@@ -15,6 +15,7 @@ export const Progressbar = Template.bind({});
 Progressbar.args = {
   total: 4,
   current: 1,
+  shrinkEmoji: false,
 };
 
 const WithSlotTemplate = (args) => ({
@@ -27,4 +28,5 @@ export const ProgressbarWithSlot = WithSlotTemplate.bind({});
 ProgressbarWithSlot.args = {
   total: 4,
   current: 1,
+  shrinkEmoji: false,
 };

--- a/packages/mikado_reborn/src/components/Progressbar/Progressbar.scss
+++ b/packages/mikado_reborn/src/components/Progressbar/Progressbar.scss
@@ -9,11 +9,17 @@
   }
 
   &__emoji {
+    $emoji: &;
+
     flex-shrink: 0;
     height: 1.5rem;
     display: flex;
     align-items: center;
     opacity: 0;
+
+    &--shrink:not(#{$emoji}--visible) {
+      display: none;
+    }
 
     &--visible {
       opacity: 1;

--- a/packages/mikado_reborn/src/components/Progressbar/Progressbar.vue
+++ b/packages/mikado_reborn/src/components/Progressbar/Progressbar.vue
@@ -6,7 +6,15 @@
     :aria-valuemax="total"
     :aria-valuenow="current"
   >
-    <div :class="['mkr__progressbar__emoji', { 'mkr__progressbar__emoji--visible': isCompleted }]">
+    <div
+      :class="[
+        'mkr__progressbar__emoji',
+        {
+          'mkr__progressbar__emoji--visible': isCompleted,
+          'mkr__progressbar__emoji--shrink': shrinkEmoji,
+        },
+      ]"
+    >
       <slot> 👍 </slot>
     </div>
     <div class="mkr__progressbar__text">{{ current }}/{{ total }}</div>
@@ -27,6 +35,9 @@ export default class Progressbar extends Vue {
 
   @Prop({ type: Number, required: true })
   total!: number;
+
+  @Prop({ type: Boolean, required: true, default: false })
+  shrinkEmoji!: boolean;
 
   get isCompleted(): boolean {
     return this.total > 0 && this.current >= this.total;


### PR DESCRIPTION
ShrinkEmoji will allow to apply `display:none` to emoji slot if no emoji is present, thus making the progress-bar full-width.